### PR TITLE
Fix: handle non 200 status code in feed jobs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,5 +26,5 @@ config :o2m,
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:url, :init, :data, :state, :template, :reason],
+  metadata: [:url, :init, :data, :state, :template, :reason, :code],
   level: :info

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -26,5 +26,5 @@ config :o2m,
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:url, :init, :data, :state, :template, :reason],
+  metadata: [:url, :init, :data, :state, :template, :reason, :code],
   level: :info


### PR DESCRIPTION
Add basic http status code check in jobs timer. 

When receiving a code not equal to 200, keep the old state.

In case init failed, fallback to a stable mode with :nodata as state and retry later.