### PR TITLE
Add config module for o2m

### DIFF
--- a/build/ci/drone.yml
+++ b/build/ci/drone.yml
@@ -25,7 +25,7 @@ steps:
       - mix local.hex --force
       - mix local.rebar --force
       - mix deps.get
-      - mix test
+      - mix test --no-start
 
   - name: docker
     image: plugins/docker

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,35 +11,8 @@ config :nostrum,
 
 # o2m configuration
 config :o2m,
-  # Nickname on Discord
-  nickname: System.get_env("O2M_NICKNAME", "Orgie 2 Metal"),
-  # Prefix used for commands
-  prefix: System.get_env("O2M_PREFIX", "!"),
   # Metalorgie url, used for `band` and `album` command
-  metalorgie: "https://www.metalorgie.com",
-  # Time between each check on feeds
-  timer: System.get_env("O2M_JOBS_TIMER", "500"),
-  # Guild ID
-  guild: System.get_env("O2M_GUILD_ID"),
-  # Channel ID
-  chan: System.get_env("O2M_CHAN_ID"),
-  # RSS podcast feed urls
-  feed_urls: System.get_env("O2M_FEED_URLS"),
-  # DETS template file
-  tmpl_dets: System.get_env("O2M_TMPL_DETS", "/srv/o2m/dets/templates.dets"),
-  # Blind tests
-  # admin role for blind-test
-  bt_admin: System.get_env("O2M_BT_ADMIN"),
-  # text channel for blind-tests
-  bt_chan: System.get_env("O2M_BT_CHAN_ID"),
-  # text channel for blind-tests
-  bt_vocal: System.get_env("O2M_BT_VOCAL_ID"),
-  # cache diredctory for songs
-  bt_cache: System.get_env("O2M_BT_CACHE", "/tmp/o2m/cache"),
-  # blind test leaderbord dets
-  bt_lboard_dets: System.get_env("O2M_BT_LBOARD_DETS", "/srv/o2m/dets/leaderboard.dets"),
-  # default timezone for events
-  bt_events_tz: System.get_env("O2M_BT_EVENTS_TZ", "Europe/Paris")
+  metalorgie: "https://www.metalorgie.com"
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -11,35 +11,8 @@ config :nostrum,
 
 # o2m configuration
 config :o2m,
-  # Nickname on Discord
-  nickname: System.get_env("O2M_NICKNAME", "Orgie 2 Metal"),
-  # Prefix used for commands
-  prefix: System.get_env("O2M_PREFIX", "!"),
   # Metalorgie url, used for `band` and `album` command
-  metalorgie: "https://www.metalorgie.com",
-  # Time between each check on feeds
-  timer: System.get_env("O2M_JOBS_TIMER", "500"),
-  # Guild ID
-  guild: System.get_env("O2M_GUILD_ID"),
-  # Channel ID
-  chan: System.get_env("O2M_CHAN_ID"),
-  # RSS podcast feed urls
-  feed_urls: System.get_env("O2M_FEED_URLS"),
-  # DETS template file
-  tmpl_dets: System.get_env("O2M_TMPL_DETS", "/srv/o2m/dets/templates.dets"),
-  # Blind tests
-  # admin role for blind-test
-  bt_admin: System.get_env("O2M_BT_ADMIN"),
-  # text channel for blind-tests
-  bt_chan: System.get_env("O2M_BT_CHAN_ID"),
-  # text channel for blind-tests
-  bt_vocal: System.get_env("O2M_BT_VOCAL_ID"),
-  # cache diredctory for songs
-  bt_cache: System.get_env("O2M_BT_CACHE", "/tmp/o2m/cache"),
-  # blind test leaderbord dets
-  bt_lboard_dets: System.get_env("O2M_BT_LBOARD_DETS", "/srv/o2m/dets/leaderboard.dets"),
-  # default timezone for events
-  bt_events_tz: System.get_env("O2M_BT_EVENTS_TZ", "Europe/Paris")
+  metalorgie: "https://www.metalorgie.com"
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/lib/blindtest/cache.ex
+++ b/lib/blindtest/cache.ex
@@ -2,6 +2,7 @@ defmodule Cache do
   @moduledoc """
   Module used to get data from filesystem to data playable by Nostrum
   """
+  alias O2M.Config
 
   @doc """
   Get a file using it's id
@@ -10,7 +11,7 @@ defmodule Cache do
   """
   def path(uuid) do
     cache =
-      Application.fetch_env!(:o2m, :bt_cache)
+      Config.get(:bt_cache)
       |> String.trim_trailing("/")
 
     file =
@@ -31,7 +32,7 @@ defmodule Cache do
   """
   def clean() do
     cache =
-      Application.fetch_env!(:o2m, :bt_cache)
+      Config.get(:bt_cache)
       |> String.trim_trailing("/")
 
     files = File.ls!(cache)

--- a/lib/blindtest/game.ex
+++ b/lib/blindtest/game.ex
@@ -430,7 +430,7 @@ defmodule Game do
   end
 
   def handle_event(:enter, _event, :transition, data) do
-    Nostrum.Voice.stop(O2M.Config.get(:bt_vocal))
+    Nostrum.Voice.stop(data.guild_id)
 
     Nostrum.Api.create_message(data.channel_id,
       embed: %Nostrum.Struct.Embed{
@@ -448,7 +448,7 @@ defmodule Game do
   end
 
   def handle_event(:enter, _event, :finished, data) do
-    Nostrum.Voice.stop(O2M.Config.get(:bt_vocal))
+    Nostrum.Voice.stop(data.guild_id)
 
     Nostrum.Api.create_message(data.channel_id,
       embed: %Nostrum.Struct.Embed{

--- a/lib/blindtest/game.ex
+++ b/lib/blindtest/game.ex
@@ -136,7 +136,7 @@ defmodule Game do
         :fields => [
           %Nostrum.Struct.Embed.Field{
             name: "Start command",
-            value: "`#{Application.fetch_env!(:o2m, :prefix)}bt start`"
+            value: "`#{O2M.Config.get(:prefix)}bt start`"
           }
         ],
         :color => Colors.get_color(:info)
@@ -305,7 +305,7 @@ defmodule Game do
           }
         )
 
-        Nostrum.Voice.play(O2M.Application.from_env_to_int(:o2m, :guild), p, :url)
+        :ok = Nostrum.Voice.play(O2M.Config.get(:guild), p, :url)
 
         {:keep_state, updated_data,
          [{:state_timeout, data.config.guess_duration * 1000, :not_guessed}]}
@@ -318,9 +318,7 @@ defmodule Game do
   end
 
   def handle_event(:enter, _event, :waiting, data) do
-    guild = O2M.Application.from_env_to_int(:o2m, :guild)
-    voice = O2M.Application.from_env_to_int(:o2m, :bt_vocal)
-    Nostrum.Voice.join_channel(guild, voice)
+    Nostrum.Voice.join_channel(O2M.Config.get(:guild), O2M.Config.get(:bt_vocal))
 
     # Start the downloader worker inside the game statem
     Downloader.Worker.start_link(data.downloader)
@@ -341,7 +339,7 @@ defmodule Game do
           },
           %Nostrum.Struct.Embed.Field{
             name: "Join command",
-            value: "`#{Application.fetch_env!(:o2m, :prefix)}bt join`"
+            value: "`#{O2M.Config.get(:prefix)}bt join`"
           },
           %Nostrum.Struct.Embed.Field{
             name: "Rules",
@@ -432,7 +430,7 @@ defmodule Game do
   end
 
   def handle_event(:enter, _event, :transition, data) do
-    Nostrum.Voice.stop(O2M.Application.from_env_to_int(:o2m, :guild))
+    Nostrum.Voice.stop(O2M.Config.get(:bt_vocal))
 
     Nostrum.Api.create_message(data.channel_id,
       embed: %Nostrum.Struct.Embed{
@@ -450,7 +448,7 @@ defmodule Game do
   end
 
   def handle_event(:enter, _event, :finished, data) do
-    Nostrum.Voice.stop(O2M.Application.from_env_to_int(:o2m, :guild))
+    Nostrum.Voice.stop(O2M.Config.get(:bt_vocal))
 
     Nostrum.Api.create_message(data.channel_id,
       embed: %Nostrum.Struct.Embed{

--- a/lib/blindtest/leaderboard.ex
+++ b/lib/blindtest/leaderboard.ex
@@ -2,11 +2,12 @@ defmodule Leaderboard do
   @moduledoc """
   Interact with the leaderboard stored in dets file
   """
+  alias O2M.Config
 
   @top 15
 
   def set(id, points) do
-    path = to_charlist(Application.fetch_env!(:o2m, :bt_lboard_dets))
+    path = to_charlist(Config.get(:bt_lboard))
 
     {:ok, table} = :dets.open_file(path, type: :set)
     ret = :dets.insert(table, {id, points})
@@ -18,7 +19,7 @@ defmodule Leaderboard do
   def delta(id, points, fun) do
     old = get(id)
 
-    path = to_charlist(Application.fetch_env!(:o2m, :bt_lboard_dets))
+    path = to_charlist(Config.get(:bt_lboard))
     {:ok, table} = :dets.open_file(path, type: :set)
 
     ret =
@@ -36,7 +37,7 @@ defmodule Leaderboard do
   end
 
   def get(id) do
-    path = to_charlist(Application.fetch_env!(:o2m, :bt_lboard_dets))
+    path = to_charlist(Config.get(:bt_lboard))
     {:ok, table} = :dets.open_file(path, type: :set)
     ret = :dets.lookup(table, id)
     :dets.close(table)
@@ -51,7 +52,7 @@ defmodule Leaderboard do
   end
 
   def update(scores) do
-    path = to_charlist(Application.fetch_env!(:o2m, :bt_lboard_dets))
+    path = to_charlist(Config.get(:bt_lboard))
     {:ok, table} = :dets.open_file(path, type: :set)
 
     scores
@@ -70,7 +71,7 @@ defmodule Leaderboard do
   end
 
   def top() do
-    path = to_charlist(Application.fetch_env!(:o2m, :bt_lboard_dets))
+    path = to_charlist(Config.get(:bt_lboard))
     {:ok, table} = :dets.open_file(path, type: :set)
     scores = :dets.match_object(table, {:"$1", :"$2"})
     sorted = Enum.sort(scores, fn {_id1, v1}, {_id2, v2} -> v1 > v2 end)

--- a/lib/commands/commands.ex
+++ b/lib/commands/commands.ex
@@ -80,13 +80,11 @@ defmodule O2M.Commands do
     """
 
     def handle(_, _, _) do
-      {:ok, prefix} = Application.fetch_env(:o2m, :prefix)
-
       reply = "**Commands**
-Using prefix `#{prefix}` :
+Using prefix `#{O2M.Config.get(:prefix)}` :
 - mo : to interact with metalorgie website and database
 - tmpl : to interact with announcement templates
-- bt : to interact with blind tests (configured: **#{BlindTest.configured?()}**)
+- bt : to interact with blind tests (configured: **#{O2M.Config.get(:bt)}**)
 - help : to get this help message
 
 **Emojis**

--- a/lib/commands/mo.ex
+++ b/lib/commands/mo.ex
@@ -1,5 +1,6 @@
 defmodule O2M.Commands.Mo do
   import Metalorgie
+  alias O2M.Config
 
   @moduledoc """
   Mo module handle call to mo command
@@ -74,8 +75,8 @@ defmodule O2M.Commands.Mo do
   """
   def help([]) do
     reply = "Available **mo** subcommands are :
-    - **album**: to get album info (try _#{Application.fetch_env!(:o2m, :prefix)}mo help album_)
-    - **band**: to get page band info (try _#{Application.fetch_env!(:o2m, :prefix)}mo help band_)
+    - **album**: to get album info (try _#{Config.get(:prefix)}mo help album_)
+    - **band**: to get page band info (try _#{Config.get(:prefix)}mo help band_)
     - **help**: to get this help message"
 
     {:ok, reply}
@@ -86,10 +87,10 @@ defmodule O2M.Commands.Mo do
     reply =
       case Enum.join(args, " ") do
         "album" ->
-          "Here is an example of \`album\` subcommand : \`\`\`#{Application.fetch_env!(:o2m, :prefix)}mo album korn // follow the leader \`\`\`"
+          "Here is an example of \`album\` subcommand : \`\`\`#{Config.get(:prefix)}mo album korn // follow the leader \`\`\`"
 
         "band" ->
-          "Here is an example of \`band\` subcommand : \`\`\`#{Application.fetch_env!(:o2m, :prefix)}mo band korn\`\`\`"
+          "Here is an example of \`band\` subcommand : \`\`\`#{Config.get(:prefix)}mo band korn\`\`\`"
 
         sub ->
           "Subcommand #{sub} not available"

--- a/lib/commands/templates.ex
+++ b/lib/commands/templates.ex
@@ -1,6 +1,7 @@
 defmodule O2M.Commands.Tmpl do
   require Logger
   import Announcements
+  alias O2M.Config
 
   @moduledoc """
   An module handle call to an command
@@ -123,9 +124,9 @@ defmodule O2M.Commands.Tmpl do
 
   def help([]) do
     reply = "Available **tmpl** subcommands are :
-    - **add**: to add an announcement template (try _#{Application.fetch_env!(:o2m, :prefix)}tmpl help add_)
-    - **list**: to list templates (try _#{Application.fetch_env!(:o2m, :prefix)}tmpl help list_)
-    - **delete**: to delete a specific template (try _#{Application.fetch_env!(:o2m, :prefix)}tmpl help delete_)
+    - **add**: to add an announcement template (try _#{Config.get(:prefix)}tmpl help add_)
+    - **list**: to list templates (try _#{Config.get(:prefix)}tmpl help list_)
+    - **delete**: to delete a specific template (try _#{Config.get(:prefix)}tmpl help delete_)
     - **help**: to get this help message"
     {:ok, reply}
   end
@@ -134,13 +135,13 @@ defmodule O2M.Commands.Tmpl do
     reply =
       case Enum.join(args, " ") do
         "add" ->
-          "Here is an example of \`add\` subcommand : \`\`\`#{Application.fetch_env!(:o2m, :prefix)}tmpl add #[show] just publish a new episode #[title], check it at #[url]\`\`\`"
+          "Here is an example of \`add\` subcommand : \`\`\`#{Config.get(:prefix)}tmpl add #[show] just publish a new episode #[title], check it at #[url]\`\`\`"
 
         "list" ->
-          "Here is an example of \`list\` subcommand : \`\`\`#{Application.fetch_env!(:o2m, :prefix)}tmpl list\`\`\`"
+          "Here is an example of \`list\` subcommand : \`\`\`#{Config.get(:prefix)}tmpl list\`\`\`"
 
         "delete" ->
-          "Here is an example of \`delete\` subcommand, using ID from list subcommand : \`\`\`#{Application.fetch_env!(:o2m, :prefix)}tmpl delete acfe\`\`\`"
+          "Here is an example of \`delete\` subcommand, using ID from list subcommand : \`\`\`#{Config.get(:prefix)}tmpl delete acfe\`\`\`"
 
         sub ->
           "Help for subcommand #{sub} not available"

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -1,0 +1,91 @@
+defmodule O2M.Config do
+  @moduledoc """
+  A module to handle o2m config from env using ETS
+  """
+
+  # base config
+  @base [
+    {:pass, :nickname, "O2M_NICKNAME", "Orgie 2 Metal"},
+    {:pass, :prefix, "O2M_PREFIX", "!"},
+    {:pass, :feed_urls, "O2M_FEED_URLS", ""},
+    {:pass, :tmpl_dets, "O2M_TMPL_DETS", "/srv/o2m/dets/templates.dets"},
+    {:convert, :jobs_timer, "O2M_JOBS_TIMER", "500"},
+    {:convert, :guild, "O2M_GUILD_ID", :no_default},
+    {:convert, :chan, "O2M_CHAN_ID", :no_default}
+  ]
+
+  # bt config
+  @bt [
+    {:convert, :bt_chan, "O2M_BT_CHAN_ID", :no_default},
+    {:convert, :bt_admin, "O2M_BT_ADMIN", :no_default},
+    {:convert, :bt_vocal, "O2M_BT_VOCAL_ID", :no_default},
+    {:pass, :bt_cache, "O2M_BT_CACHE", "/tmp/o2m/cache"},
+    {:pass, :bt_lboard, "O2M_BT_LBOARD_DETS", "/srv/o2m/dets/leaderboard.dets"},
+    {:pass, :bt_events_tz, "O2M_BT_EVENTS_TZ", "Europe/Paris"}
+  ]
+
+  @bt_mandatory_keys [
+    "O2M_BT_ADMIN",
+    "O2M_BT_CHAN_ID",
+    "O2M_BT_VOCAL_ID"
+  ]
+
+  def init!() do
+    :ets.new(:config_lookup, [:set, :protected, :named_table])
+
+    insert!(@base)
+
+    if blindtest?() do
+      insert!(@bt)
+      insert!({:bt, true})
+    end
+
+    :config_lookup
+  end
+
+  def get(key) do
+    [{_, v}] = :ets.lookup(:config_lookup, key)
+    v
+  end
+
+  defp get_env!({convert, key, env_key, :no_default}) do
+    case System.get_env(env_key) do
+      nil -> raise "No key found for mandatory env value #{key}"
+      value -> {convert, key, value}
+    end
+  end
+
+  defp get_env!({convert, key, env_key, default}),
+    do: {convert, key, System.get_env(env_key, default)}
+
+  defp to_int!({:convert, key, value}) do
+    case Integer.parse(value) do
+      {parsed, ""} -> {key, parsed}
+      :error -> raise "Error when trying to parse integer value #{value}"
+    end
+  end
+
+  defp to_int!({:pass, key, value}), do: {key, value}
+
+  defp insert!(entries) when is_list(entries) do
+    # Env with default
+    for entry <- entries do
+      entry
+      |> get_env!()
+      |> to_int!()
+      |> insert!()
+    end
+  end
+
+  defp insert!({key, value}), do: :ets.insert_new(:config_lookup, {key, value})
+
+  defp blindtest?() do
+    configured = Enum.take_while(@bt_mandatory_keys, &(System.get_env(&1) != nil))
+
+    length(@bt_mandatory_keys) == length(configured)
+  end
+
+  def purge! do
+    :ets.delete(:config_lookup)
+  end
+end

--- a/lib/o2m.ex
+++ b/lib/o2m.ex
@@ -2,6 +2,7 @@ defmodule O2M do
   @moduledoc """
   A simple Elixir module based on Nostrum to interact with Discord
   """
+  alias O2M.Config
 
   # This is a Nostrum Consumer
   use Nostrum.Consumer
@@ -22,11 +23,8 @@ defmodule O2M do
   def handle_event({:MESSAGE_CREATE, msg, _ws_state}) when msg.author.bot, do: :ignore
 
   def handle_event({:MESSAGE_CREATE, msg, _ws_state}) do
-    # fetch prefix
-    {:ok, prefix} = Application.fetch_env(:o2m, :prefix)
-
     msg
-    |> enrich_message(prefix)
+    |> enrich_message(Config.get(:prefix))
     |> handle_message()
   end
 
@@ -49,7 +47,7 @@ defmodule O2M do
   def handle_message({:msg, msg}) when msg.content == "", do: :ignore
 
   def handle_message({:msg, msg}),
-    do: BlindTest.handle_message(msg, O2M.Application.from_env_to_int(:o2m, :bt_chan))
+    do: BlindTest.handle_message(msg, Config.get(:bt_chan))
 
   def handle_reaction(reaction) do
     case reaction.emoji.name do

--- a/lib/watcher/announcements.ex
+++ b/lib/watcher/announcements.ex
@@ -19,13 +19,6 @@ defmodule Announcements do
   end
 
   @doc """
-  Get default value from end
-  """
-  def get_default() do
-    Application.fetch_env!(:o2m, :default_message)
-  end
-
-  @doc """
   Get keys from placeholders
 
   ## Examples
@@ -138,7 +131,7 @@ defmodule Announcements do
     def put(template) do
       case get_all() |> length() do
         l when l < @limit ->
-          path = to_charlist(Application.fetch_env!(:o2m, :tmpl_dets))
+          path = to_charlist(O2M.Config.get(:tmpl_dets))
           {:ok, table} = :dets.open_file(path, type: :set)
           ret = :dets.insert_new(table, {genkey(template), template})
           :dets.close(table)
@@ -158,7 +151,7 @@ defmodule Announcements do
     List all stored templates
     """
     def get_all() do
-      path = to_charlist(Application.fetch_env!(:o2m, :tmpl_dets))
+      path = to_charlist(O2M.Config.get(:tmpl_dets))
       {:ok, table} = :dets.open_file(path, type: :set)
       objs = :dets.match_object(table, {:"$1", :"$2"})
       :dets.close(table)
@@ -169,7 +162,7 @@ defmodule Announcements do
     Remove a specific stored template
     """
     def delete(hash) do
-      path = to_charlist(Application.fetch_env!(:o2m, :tmpl_dets))
+      path = to_charlist(O2M.Config.get(:tmpl_dets))
       {:ok, table} = :dets.open_file(path, type: :set)
       ret = :dets.delete(table, hash)
       :dets.close(table)

--- a/lib/watcher/jobs.ex
+++ b/lib/watcher/jobs.ex
@@ -5,6 +5,7 @@ defmodule Jobs do
   use GenServer
   require Logger
   alias Nostrum.Api
+  alias O2M.Config
 
   ## GenServer API
   @doc """
@@ -43,18 +44,9 @@ defmodule Jobs do
     {:noreply, state, {:continue, :work}}
   end
 
-  @doc """
-  Get timer config from `config.exs` file
-
-  Returns timer configuration
-  """
-  def get_timer_config() do
-    O2M.Application.from_env_to_int(:o2m, :timer)
-  end
-
   defp work_then_reschedule({url, state}) do
     # Wait
-    Process.send_after(self(), :work, get_timer_config() * 1000)
+    Process.send_after(self(), :work, Config.get(:jobs_timer) * 1000)
 
     # Get last episode from feed
     next =
@@ -73,7 +65,7 @@ defmodule Jobs do
     if Feed.compare_dates(old.date, new.date) == -1 do
       # Post a message
       Api.create_message(
-        O2M.Application.from_env_to_int(:o2m, :chan),
+        Config.get(:chan),
         Feed.new_message(new)
       )
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule O2M.MixProject do
   def project do
     [
       app: :o2m,
-      version: "0.12.1",
+      version: "0.12.2",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Application.ensure_all_started(:hackney)
+
 ExUnit.start()


### PR DESCRIPTION
Drop the hard link between config application and mix config.

Use plain environment variables and build a shared, readonly config module using ETS.

Avoid and remove the old `from_env_to_int`, 🤮