### PR TITLE
feat: Add Steaming Finder

### DIFF
--- a/lib/o2m.ex
+++ b/lib/o2m.ex
@@ -53,6 +53,7 @@ defmodule O2M do
     case reaction.emoji.name do
       "📌" -> Reminder.remind(reaction)
       "👀" -> Reminder.delete(reaction)
+      "🔗" -> StreamingFinder.handle(reaction)
       _ -> :ignore
     end
   end

--- a/lib/streaming_finder.ex
+++ b/lib/streaming_finder.ex
@@ -1,0 +1,50 @@
+defmodule StreamingFinder do
+  @url_regex ~r/(https?:\/\/[^\s]+)/i
+  @max_urls 3
+
+  def handle(reaction) do
+    {:ok, origin} = Nostrum.Api.get_channel_message(reaction.channel_id, reaction.message_id)
+
+    case extract_urls(origin.content) do
+      [] ->
+        Nostrum.Api.create_reaction(origin.channel_id, origin.id, "🖕")
+
+      urls ->
+        for url <- urls |> Enum.take(@max_urls) do
+          case Odesli.get(url) do
+            {:ok, %Odesli.Response{artist: artist, title: title, urls: urls}} ->
+              Odesli.get(url)
+
+              Nostrum.Api.create_message(origin.channel_id,
+                embed: message(artist, title, urls),
+                message_reference: %{message_id: origin.id}
+              )
+
+            {:error, :no_match} ->
+              Nostrum.Api.create_reaction(origin.channel_id, origin.id, "🤷")
+          end
+        end
+    end
+  end
+
+  defp message(artist, title, urls) do
+    formatted_links =
+      urls
+      |> Enum.map(fn {platform, url} ->
+        "[#{String.capitalize(platform)}](<#{url}>)"
+      end)
+      |> Enum.join(" - ")
+
+    %Nostrum.Struct.Embed{
+      :title => "#{artist} - #{title}",
+      :color => 431_948,
+      :description => formatted_links
+    }
+  end
+
+  defp extract_urls(content) do
+    Regex.scan(@url_regex, content)
+    |> List.flatten()
+    |> Enum.uniq()
+  end
+end

--- a/lib/utils/odesli.ex
+++ b/lib/utils/odesli.ex
@@ -1,0 +1,44 @@
+defmodule Odesli do
+  @api_version "v1-alpha.1"
+  @base_url "https://api.song.link"
+  @links_url "#{@base_url}/#{@api_version}/links"
+
+  @platforms ["spotify", "deezer", "appleMusic", "youtube", "bandcamp", "tidal"]
+
+  defmodule Response do
+    defstruct [:artist, :title, :urls]
+  end
+
+  def get(url) do
+    {:ok, resp} = HTTPoison.get("#{@links_url}?#{URI.encode_query(%{url: url})}")
+
+    case resp do
+      %HTTPoison.Response{status_code: 200} ->
+        parsed = Jason.decode!(resp.body)
+
+        meta = parsed["entitiesByUniqueId"] |> Map.values() |> List.first()
+
+        {:ok,
+         %Response{
+           artist: meta["artistName"],
+           title: meta["title"],
+           urls: plateform_urls(parsed)
+         }}
+
+      _ ->
+        {:error, :no_match}
+    end
+  end
+
+  defp plateform_urls(%{"linksByPlatform" => links}) do
+    Enum.reduce(@platforms, %{}, fn plt, acc ->
+      link = links[plt]["url"]
+
+      if link do
+        Map.put(acc, plt, link)
+      else
+        acc
+      end
+    end)
+  end
+end


### PR DESCRIPTION
## Changes

This PR adds a new feature for finding relevant links from one streaming platform to another.

It uses odesli/songlist to do so.

![2024-08-10-213745_1096x777_scrot](https://github.com/user-attachments/assets/fec0337e-3dc7-4981-b2cf-099c9eb89d47)
