### PR TITLE
fix(Streaming Links): Add missing help and increase timeout value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ erl_crash.dump
 o2m-*.tar
 
 .elixir_ls
+
+.idea
+o2m.iml

--- a/lib/commands/commands.ex
+++ b/lib/commands/commands.ex
@@ -88,6 +88,7 @@ Using prefix `#{O2M.Config.get(:prefix)}` :
 - help : to get this help message
 
 **Emojis**
+- 🔗 : find links for all streaming plateforms from the resources linked in the message content
 - 📌 : add this emoji as a reaction to pin a public message in order to get a private reminder about the pinned message
 - 👀️️ : in your private channel with the bot add this emoji as a reaction to delete a bot message"
       {:ok, reply}

--- a/lib/utils/odesli.ex
+++ b/lib/utils/odesli.ex
@@ -5,12 +5,14 @@ defmodule Odesli do
 
   @platforms ["spotify", "deezer", "appleMusic", "youtube", "bandcamp", "tidal"]
 
+  @timeout 20_000
+
   defmodule Response do
     defstruct [:artist, :title, :urls]
   end
 
   def get(url) do
-    {:ok, resp} = HTTPoison.get("#{@links_url}?#{URI.encode_query(%{url: url})}")
+    {:ok, resp} = HTTPoison.get("#{@links_url}?#{URI.encode_query(%{url: url})}", [], timeout: @timeout, recv_timout: @timeout)
 
     case resp do
       %HTTPoison.Response{status_code: 200} ->

--- a/lib/utils/odesli.ex
+++ b/lib/utils/odesli.ex
@@ -5,7 +5,7 @@ defmodule Odesli do
 
   @platforms ["spotify", "deezer", "appleMusic", "youtube", "bandcamp", "tidal"]
 
-  @timeout 20_000
+  @timeout :timer.minutes(0.5)
 
   defmodule Response do
     defstruct [:artist, :title, :urls]


### PR DESCRIPTION
## Context :monocle_face: 

Odesli is sometime slow when requesting all plateforms, resulting in an error/no message from the bot. HTTPoison has a relatively low default timeout.

## Changes :pick: 

- Increase timeout when requesting Odesli
- Added missing help for streaming links feature