### PR TITLE
fix/emojos: ensure proper encoding of emojis when sending react

### DIFF
--- a/lib/blindtest/blindtest.ex
+++ b/lib/blindtest/blindtest.ex
@@ -283,15 +283,11 @@ defmodule BlindTest do
 
       :already ->
         # ⏰
-        Message.react(bt_channel_id, msg.id, %Nostrum.Struct.Emoji{
-          name: Emojos.get(:already)
-        })
+        Discord.react(msg, Emojos.get(:already))
 
       :f1 ->
         # 🎤
-        Message.react(bt_channel_id, msg.id, %Nostrum.Struct.Emoji{
-          name: Emojos.get(:f1)
-        })
+        Discord.react(msg, Emojos.get(:f1))
 
         Message.create(
           bt_channel_id,
@@ -300,9 +296,7 @@ defmodule BlindTest do
 
       :f2 ->
         # 💿
-        Message.react(bt_channel_id, msg.id, %Nostrum.Struct.Emoji{
-          name: Emojos.get(:f2)
-        })
+        Discord.react(msg, Emojos.get(:f2))
 
         Message.create(
           bt_channel_id,
@@ -311,9 +305,7 @@ defmodule BlindTest do
 
       :both ->
         # 🏆
-        Message.react(bt_channel_id, msg.id, %Nostrum.Struct.Emoji{
-          name: Emojos.get(:both)
-        })
+        Discord.react(msg, Emojos.get(:both))
 
         Message.create(
           bt_channel_id,

--- a/lib/blindtest/blindtest.ex
+++ b/lib/blindtest/blindtest.ex
@@ -317,7 +317,7 @@ defmodule BlindTest do
 
         Message.create(
           bt_channel_id,
-         "#{Discord.mention(msg.author.id)} just found both fields and earned #{points} points !"
+          "#{Discord.mention(msg.author.id)} just found both fields and earned #{points} points !"
         )
     end
   end

--- a/lib/blindtest/game.ex
+++ b/lib/blindtest/game.ex
@@ -1,5 +1,6 @@
 defmodule Game do
   alias Nostrum.Api.Message
+
   @moduledoc """
   State Machine used for blind tests
   """

--- a/lib/commands/blindtest.ex
+++ b/lib/commands/blindtest.ex
@@ -52,7 +52,7 @@ defmodule O2M.Commands.Bt do
   """
   def init(args, msg) do
     with {:ok, _chan} <- is_chan_private(msg.channel_id),
-         {:ok} <- member_has_persmission(msg.author, Config.get(:bt_admin), Config.get(:guild)),
+         {:ok} <- member_has_permission(msg.author, Config.get(:bt_admin), Config.get(:guild)),
          {:ok} <- BlindTest.ensure_not_running() do
       BlindTest.init(msg.attachments, msg.author, msg.channel_id, args)
     else
@@ -225,7 +225,7 @@ defmodule O2M.Commands.Bt do
   """
   def start(_args, msg) do
     with {:ok} <- BlindTest.ensure_running(),
-         {:ok} <- member_has_persmission(msg.author, Config.get(:bt_admin), Config.get(:guild)),
+         {:ok} <- member_has_permission(msg.author, Config.get(:bt_admin), Config.get(:guild)),
          {:ok} <- BlindTest.ensure_channel(msg.channel_id) do
       case Game.start_game() do
         {:ok, _} ->
@@ -358,7 +358,7 @@ defmodule O2M.Commands.Bt do
     guild_id = Config.get(:guild)
 
     with {:ok} <- BlindTest.ensure_running(),
-         {:ok} <- member_has_persmission(msg.author, Config.get(:bt_admin), guild_id),
+         {:ok} <- member_has_permission(msg.author, Config.get(:bt_admin), guild_id),
          {:ok} <- BlindTest.ensure_channel(msg.channel_id) do
       downloarder_pid = Process.whereis(Downloader.Worker)
       # kill downloader is any
@@ -478,7 +478,7 @@ defmodule O2M.Commands.Bt do
   end
 
   def lboard(["top" | _], msg) do
-    with {:ok} <- member_has_persmission(msg.author, Config.get(:bt_admin), Config.get(:guild)) do
+    with {:ok} <- member_has_permission(msg.author, Config.get(:bt_admin), Config.get(:guild)) do
       reply =
         Leaderboard.top()
         |> Enum.with_index()
@@ -497,7 +497,7 @@ defmodule O2M.Commands.Bt do
   end
 
   def lboard(["set", _user, <<instruction::binary-size(1)>> <> points | _], msg) do
-    with {:ok} <- member_has_persmission(msg.author, Config.get(:bt_admin), Config.get(:guild)),
+    with {:ok} <- member_has_permission(msg.author, Config.get(:bt_admin), Config.get(:guild)),
          {:ok} <- BlindTest.ensure_channel(msg.channel_id) do
       case Integer.parse(points) do
         {val, _} ->
@@ -543,7 +543,7 @@ defmodule O2M.Commands.Bt do
 
   def party(["reset" | _], msg) do
     with {:ok} <-
-           Discord.member_has_persmission(msg.author, Config.get(:bt_admin), Config.get(:guild)) do
+           Discord.member_has_permission(msg.author, Config.get(:bt_admin), Config.get(:guild)) do
       Party.reset()
       {:ok, "🙌  Party cleared  🙌"}
     else
@@ -660,7 +660,7 @@ defmodule O2M.Commands.Bt do
     guild_id = Config.get(:guild)
 
     with {:ok} <-
-           Discord.member_has_persmission(msg.author, Config.get(:bt_admin), guild_id),
+           Discord.member_has_permission(msg.author, Config.get(:bt_admin), guild_id),
          {:ok, date} <- Timex.parse(date, "{YYYY}-{0M}-{D}@{h24}:{m}"),
          with_tz <- Timex.to_datetime(date, Config.get(:bt_events_tz)) do
       options = %{
@@ -711,7 +711,7 @@ defmodule O2M.Commands.Bt do
     guild_id = Config.get(:guild)
 
     with {:ok} <-
-           Discord.member_has_persmission(msg.author, Config.get(:bt_admin), guild_id),
+           Discord.member_has_permission(msg.author, Config.get(:bt_admin), guild_id),
          {:ok} <- BlindTest.ensure_channel(msg.channel_id),
          {:ok, event} <- Nostrum.Api.ScheduledEvent.get(guild_id, id),
          {:ok, players} <- Nostrum.Api.ScheduledEvent.users(guild_id, event.id) do

--- a/lib/commands/blindtest.ex
+++ b/lib/commands/blindtest.ex
@@ -123,9 +123,7 @@ defmodule O2M.Commands.Bt do
       Game.add_player(msg.author.id)
 
       # 👌
-      Message.react(msg.channel_id, msg.id, %Nostrum.Struct.Emoji{
-        name: Emojos.get(:joined)
-      })
+      Discord.react(msg, Emojos.get(:joined))
 
       {:ok, :silent}
     else
@@ -291,25 +289,19 @@ defmodule O2M.Commands.Bt do
       case Game.player_pass(msg.author.id) do
         {:ok, :passed} ->
           # ⏩
-          Message.react(msg.channel_id, msg.id, %Nostrum.Struct.Emoji{
-            name: Emojos.get(:passed)
-          })
+          Discord.react(msg, Emojos.get(:passed))
 
           {:ok, :silent}
 
         {:ok, :skips} ->
           # ⏩
-          Message.react(msg.channel_id, msg.id, %Nostrum.Struct.Emoji{
-            name: Emojos.get(:passed)
-          })
+          Discord.react(msg, Emojos.get(:passed))
 
           {:ok, "STOP THE COUNT, I skip this guess"}
 
         {:ok, :already_passed} ->
           # 🖕
-          Message.react(msg.channel_id, msg.id, %Nostrum.Struct.Emoji{
-            name: Emojos.get(:already_passed)
-          })
+          Discord.react(msg, Emojos.get(:already_passed))
 
           {:ok, :silent}
 
@@ -614,9 +606,7 @@ defmodule O2M.Commands.Bt do
     Party.add_player(msg.author.id)
 
     # 👌
-    Message.react(msg.channel_id, msg.id, %Nostrum.Struct.Emoji{
-      name: Emojos.get(:joined)
-    })
+    Discord.react(msg, Emojos.get(:joined))
 
     {:ok, :silent}
   end

--- a/lib/streaming_finder.ex
+++ b/lib/streaming_finder.ex
@@ -9,7 +9,7 @@ defmodule StreamingFinder do
 
     case extract_urls(origin.content) do
       [] ->
-        Message.react(origin.channel_id, origin.id, "🖕")
+        Discord.react(origin, "🖕")
 
       urls ->
         for url <- urls |> Enum.take(@max_urls) do
@@ -22,7 +22,7 @@ defmodule StreamingFinder do
               )
 
             {:error, :no_match} ->
-              Message.react(origin.channel_id, origin.id, "🤷")
+              Discord.react(origin, "🤷")
           end
         end
     end

--- a/lib/utils/discord.ex
+++ b/lib/utils/discord.ex
@@ -32,7 +32,7 @@ defmodule Discord do
 
   Returns an atom indicating role membership
   """
-  def member_has_persmission(user, rid, gid) do
+  def member_has_permission(user, rid, gid) do
     with {:ok, member} <- Nostrum.Cache.MemberCache.get(gid, user.id) do
       if Enum.member?(member.roles, rid) do
         {:ok}

--- a/lib/utils/discord.ex
+++ b/lib/utils/discord.ex
@@ -61,4 +61,10 @@ defmodule Discord do
   def channel(id) do
     "<##{id}>"
   end
+
+  @doc """
+  Small wrapper to ensure emoji is encoded in order to react properly
+  """
+  def react(origin, emoji),
+    do: Nostrum.Api.Message.react(origin.channel_id, origin.id, URI.encode(emoji))
 end


### PR DESCRIPTION
Fixing issue cause by migration to newer Nostrum API. Reaction in emojis where not properly encoded anymore